### PR TITLE
[Myles] Void Pointer Arithmatic

### DIFF
--- a/vendor/gt.h
+++ b/vendor/gt.h
@@ -306,7 +306,7 @@ void gtgo(void (*entry)(void* arg), void* arg) {
             perror("mmap stack");
             exit(1);
         }
-        thread->sp_base += GT_STACK_SIZE;
+        thread->sp_base = (void *)((char *)thread->sp_base + GT_STACK_SIZE);
     #endif
     } else {
         thread = (GThread*)scheduler.dead.next;


### PR DESCRIPTION
Removed void pointer arithmetic as this is forbidden with -pedantic